### PR TITLE
Multiple Updates to Documentation.

### DIFF
--- a/apis/dicom-web-intro.md
+++ b/apis/dicom-web-intro.md
@@ -65,6 +65,7 @@ Interested in pushing data to the server? [This article](./dicom-web-stow.md) pr
 
 ## Resources
 * [DICOMweb documentation](http://www.dicomweb.org/)
+* [DICOMweb CheatSheet](https://www.dicomstandard.org/docs/librariesprovider2/dicomdocuments/dicom/wp-content/uploads/2018/04/dicomweb-cheatsheet.pdf)
 * [QIDO-RS](ftp://medical.nema.org/medical/dicom/final/sup166_ft5.pdf)
 * [WADO-RS](ftp://medical.nema.org/medical/dicom/final/sup161_ft.pdf)
 * [STOW-RS](ftp://medical.nema.org/medical/dicom/Final/sup163_ft3.pdf)

--- a/apis/fhir-intro.md
+++ b/apis/fhir-intro.md
@@ -48,6 +48,14 @@ Who wouldn't? Right?!? Have a look at [https://replit.com/@mohannadhussain/fhir-
 * [Gino Canessa FHIR Tutorials](https://www.youtube.com/@GinoCanessa)
 * [Sidharth Ramesh - MedBlocks FHIR Tutorials](https://www.youtube.com/@medblocks)
 
+## FHIR Forums / User Groups
+
+* [FHIR Chat - You can also use Zulip](https://chat.fhir.org/)
+* [Zulip, client and server - Organized chat for distributed teams](https://zulip.com/)
+
+
+
+
 
 
 

--- a/apis/fhir-intro.md
+++ b/apis/fhir-intro.md
@@ -43,7 +43,7 @@ Who wouldn't? Right?!? Have a look at [https://replit.com/@mohannadhussain/fhir-
 
 * [Python HL7 Package - GitHub](https://github.com/crs4/hl7apy)
 
-## YouTube Video Channels for FHIR:
+## YouTube Video Channels for FHIR
 
 * [Gino Canessa FHIR Tutorials](https://www.youtube.com/@GinoCanessa)
 * [Sidharth Ramesh - MedBlocks FHIR Tutorials](https://www.youtube.com/@medblocks)

--- a/apis/fhir-intro.md
+++ b/apis/fhir-intro.md
@@ -33,5 +33,23 @@ Who wouldn't? Right?!? Have a look at [https://replit.com/@mohannadhussain/fhir-
 
 ## Resources
 * [FHIR Home Page](https://www.hl7.org/fhir/index.html)
+* [FHIR HAPI JPAServer Starter GitHub](https://github.com/hapifhir/hapi-fhir-jpaserver-starter)
 * [Searching using FHIR](https://www.hl7.org/fhir/search.html)
 * [Patient Resource](https://www.hl7.org/fhir/patient.html)
+
+
+* [Python Package for FHIR resources](https://pypi.org/project/fhir.resources/)
+* [Python Package - a FHIR Client](https://github.com/smart-on-fhir/client-py)
+
+* [Python HL7 Package - GitHub](https://github.com/crs4/hl7apy)
+
+## YouTube Video Channels for FHIR:
+
+* [Gino Canessa FHIR Tutorials](https://www.youtube.com/@GinoCanessa)
+* [Sidharth Ramesh - MedBlocks FHIR Tutorials](https://www.youtube.com/@medblocks)
+
+
+
+
+
+

--- a/imaging/dcm4che.md
+++ b/imaging/dcm4che.md
@@ -1,0 +1,5 @@
+# Useful Links for DCM4CHE
+
+* [Home Page](https://web.dcm4che.org/)
+
+* [GitHub](https://github.com/dcm4che/dcm4che)

--- a/imaging/orthanc.md
+++ b/imaging/orthanc.md
@@ -1,0 +1,13 @@
+# Useful Links for Orthanc
+
+* [Home Page](https://www.orthanc-server.com/)
+
+* [Downloads Page](https://www.orthanc-server.com/download.php)
+
+* [Orthanc Book](https://orthanc.uclouvain.be/book/)
+
+* [Rest API CheatSheet](https://orthanc.uclouvain.be/book/users/rest-cheatsheet.html)
+
+* [Comprehensive API Summary - ReDoc](https://orthanc.uclouvain.be/api/index.html)
+
+* [orthancteam Docker Images](https://hub.docker.com/u/orthancteam)

--- a/miscellaneous/contributing.md
+++ b/miscellaneous/contributing.md
@@ -6,6 +6,23 @@ Do you see a spelling error? Or maybe you have some cool information to add? We'
 
 Everything you see in these docs is authored using [Markdown](https://en.wikipedia.org/wiki/Markdown) in Github. Simply fork this project [https://github.com/ImagingInformatics/hackathon-docs](https://github.com/ImagingInformatics/hackathon-docs), make your changes then submit a pull request.
 
+To work on the documentation you do need to have Python installed and you will need to install some Python packages:
+
+```
+pip3 install mkdocs
+pip3 install mkdocs-same-dir
+```
+
+After that, simply execute the following.
+
+```
+mkdocs serve
+```
+
+and visit:  [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
+
+There is more documentation about MkDocs here:  [MkDocs User Guide](https://www.mkdocs.org/user-guide/)
+
 ## SIIM Hackathon Dataset
 We are always in search of volunteers to help enrich our dataset. Below are some ideas for things people can contribute, but we are definitely open to other ideas as well.
 

--- a/miscellaneous/dicom-resources.md
+++ b/miscellaneous/dicom-resources.md
@@ -1,0 +1,13 @@
+# Python Libraries and Development Tools for DICOM
+
+* [Dicom ToolKit - dcmtk](https://dicom.offis.de/dcmtk.php.en)
+
+* [PyDicom](https://github.com/pydicom/pydicom)
+
+* [PyNetDicom](https://github.com/pydicom/pynetdicom)
+
+* [DVTk - Windows Dev Tools](https://www.dvtk.org/downloads/)
+
+* [DCM4CHE Toolkit](https://github.com/dcm4che/dcm4che)
+
+* [Dicom Browser](https://dicom.innolitics.com/ciods)

--- a/miscellaneous/docker.md
+++ b/miscellaneous/docker.md
@@ -1,0 +1,5 @@
+# Docker Links
+
+* [Docker Desktop](https://www.docker.com/)
+
+* [Docker Hub](https://hub.docker.com/)

--- a/miscellaneous/ides.md
+++ b/miscellaneous/ides.md
@@ -1,0 +1,5 @@
+# Suggested IDE's / Tools 
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+
+* [PyCharm](https://www.jetbrains.com/pycharm/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,9 @@ nav:
         - Generative AI: apis/generative-ai.md
         - Ethereum Intro: apis/ethereum-blockchain-intro.md
         - Other APIs/Standards: apis/other-apis-and-standards.md
+    - Image Archives:
+        - Orthanc: imaging/orthanc.md
+        - DCM4CHEE: imaging/dcm4chee.md
     - Miscellaneous:
         - Data Sets: miscellaneous/data-sets.md
         - Contributing: miscellaneous/contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,11 @@ nav:
         - Other APIs/Standards: apis/other-apis-and-standards.md
     - Image Archives:
         - Orthanc: imaging/orthanc.md
-        - DCM4CHEE: imaging/dcm4chee.md
+        - DCM4CHE: imaging/dcm4che.md
     - Miscellaneous:
+        - DICOM Resources: miscellaneous/dicom-resources.md
+        - IDE's: miscellaneous/ides.md
+        - Docker: miscellaneous/docker.md
         - Data Sets: miscellaneous/data-sets.md
         - Contributing: miscellaneous/contributing.md
 plugins:


### PR DESCRIPTION
1. Added Cheatsheet for DicomWeb under Resources.
2. Added links to FHIR Resources. HAPI server, Python packages, Youtube channel links.
3. Added side panel section for Image Archives and Placeholders for Orthanc and DCM4CHEE
4. Added instructions on how to build and run MkDocs locally for contributors.

Added sections for Image Archives

1. Imaging, dcm4che and orthanc.
2. New miscellaneous sections.

Added external links for FHIR video tutorials and FHIR Chat, etc.